### PR TITLE
tpm2_getmanufec: RetrieveEndorsementCredentials(): fix curl_easy_seto…

### DIFF
--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -452,7 +452,7 @@ int RetrieveEndorsementCredentials(char *b64h)
      * If verbose is set, add in diagnostic information for debugging connections.
      * https://curl.haxx.se/libcurl/c/CURLOPT_VERBOSE.html
      */
-    rc = curl_easy_setopt(curl, CURLOPT_VERBOSE, ctx.verbose);
+    rc = curl_easy_setopt(curl, CURLOPT_VERBOSE, (long)ctx.verbose);
     if (rc != CURLE_OK) {
         LOG_ERR("curl_easy_setopt for CURLOPT_VERBOSE failed: %s", curl_easy_strerror(rc));
         goto out_easy_cleanup;


### PR DESCRIPTION
…pt() call

curl_easy_setopt() expects the 3rd parameter to be a long, but it's a bool here and fails with:

```
tools/tpm2_getmanufec.c: In function 'RetrieveEndorsementCredentials':
tools/tpm2_getmanufec.c:456:992: error: call to '_curl_easy_setopt_err_long' declared with attribute warning: curl_easy_setopt expects a long argument for this option [-Werror]
cc1: all warnings being treated as errors
```
This patch fixes the problem by casting the parameter to long.